### PR TITLE
Added some features

### DIFF
--- a/theme/webcomic_theme_4.0.html
+++ b/theme/webcomic_theme_4.0.html
@@ -146,6 +146,9 @@ http://www.gnu.org/licenses/gpl-2.0.html
 
 	<!-- Booleans -->
 	<meta name="if:Repeat background image" content="0">
+	<meta name="if:Fixed Background image" content="0">
+	<meta name="select:Background image position" content="top" title="top">
+	<meta name="select:Background image position" content="bottom" title="bottom">
 	<meta name="if:Repeat header image" content="0">
 	<meta name="if:Repeat aside image" content="0">	
 
@@ -251,6 +254,10 @@ http://www.gnu.org/licenses/gpl-2.0.html
 	{block:IFBackgroundImage}
 	body { background: {BackgroundColor} url({image:Background}) no-repeat top center; }
 	{/block:IFBackgroundImage}
+
+	{block:IfFixedBackgroundImage}
+	body { background-attachment: fixed; }
+	{block:IfFixedBackgroundImage}
 
 	{block:IfRepeatBackgroundImage}
 	body { background-repeat:repeat; background-size: auto; }

--- a/theme/webcomic_theme_4.0.html
+++ b/theme/webcomic_theme_4.0.html
@@ -154,6 +154,7 @@ http://www.gnu.org/licenses/gpl-2.0.html
 
 	<meta name="if:Big header" content="0"> 
 	<meta name="if:Show title in nav bar" content="0">
+	<meta name="if:Show title in about box" content="0">
 	<meta name="if:Navigation fixed top" content="0">
 	<meta name="if:Show navigation" content="1">
 	<meta name="if:Show home link" content="1">
@@ -1286,7 +1287,7 @@ http://www.gnu.org/licenses/gpl-2.0.html
 	<aside>
 		{block:ShowDescription}
 		<section class="postscript">
-			<h4 class="title">{lang:About}</h4>
+			<h4 class="title">{lang:About}{block:IfShowTitleInAboutBox} {Title}{/block:IfShowTitleInAboutBox}</h4>
 			{block:ShowAvatar} 
 			<a href="{BlogURL}" title="{lang:Home}"><img class="user-avatar alignleft " src="{PortraitURL-128}"/></a>
 			{/block:ShowAvatar}

--- a/theme/webcomic_theme_4.0.html
+++ b/theme/webcomic_theme_4.0.html
@@ -161,6 +161,7 @@ http://www.gnu.org/licenses/gpl-2.0.html
 	<meta name="if:Show top pagination" content="0"/>
 	<meta name="if:Comic pagination" content="0">
 	<meta name="if:Clickable image" content="0">
+	<meta name="if:Clickable photoset" content="0">
 	<meta name="if:Random button" content="0">
 	<meta name="if:Back to top button" content="1">
 	<meta name="if:Large photoset" content="0">
@@ -881,7 +882,25 @@ http://www.gnu.org/licenses/gpl-2.0.html
 				{block:IfLargePhotoset}
 				{block:Photos}
 				<figure class="photo-hires-item">
+					{block:IfClickablePhotoset}
+						{block:PermalinkPagination}
+							{block:NextPost}<a href="{NextPost}">{/block:NextPost}
+						{/block:PermalinkPagination}
+						{block:Pagination}
+							{block:PreviousPage}<a href="{PreviousPage}">{/block:PreviousPage}
+						{/block:Pagination}
+					{/block:IfClickablePhotoset}
+
 					<img src="{PhotoURL-250}" class="photoset-image" />
+
+					{block:IfClickablePhotoset}
+						{block:PermalinkPagination}
+							{block:NextPost}</a>{/block:NextPost}
+						{/block:PermalinkPagination}
+						{block:Pagination}
+							{block:PreviousPage}</a>{/block:PreviousPage}
+						{/block:Pagination}
+					{/block:IfClickablePhotoset}
 				</figure>
 				{/block:Photos}
 				{/block:IfLargePhotoset}


### PR DESCRIPTION
I did a few additions to the theme for my own purposes. You might be interested in my first commit (about photosets), I'm not sure about the other two.

My use case: My comic pages are fairly large and differ in height which causes tumblr to scale them down. To avoid that I cut each page in two or three parts and upload them in a single post, where they are displayed like a single image. The problem: image sets are not clickable like single images. Fixed that in my first commit.

The second commit simply adds support for fixed background images (which I like to use in my blogs, I don't know whether it's useful for anyone else).

The third commit adds the title to the about box (like this: "About My Comic Name")